### PR TITLE
Added Menus

### DIFF
--- a/src/components/Menus/Menu.tsx
+++ b/src/components/Menus/Menu.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type MenuProps = {
+    children : React.ReactNode
+}
+
+export default function Menu(props: MenuProps) {
+    return(
+        <div
+            style={{
+                width: '200px',
+                // minWidth: '112px',
+                // maxWidth: '280px',
+                backgroundColor: 'rgb(var(--md-sys-color-surface-container))',
+                height: 'fit-content',
+                borderRadius: '4px',
+                display: 'flex',
+                justifyContent: 'start',
+                alignItems: 'center',
+                flexDirection: 'column',
+                // overflow: 'hidden'
+            }}
+            className="md-elevation-2"
+        >
+            {
+                props.children
+            }
+        </div>
+    );
+};
+

--- a/src/components/Menus/Menu.tsx
+++ b/src/components/Menus/Menu.tsx
@@ -1,10 +1,29 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 type MenuProps = {
-    children : React.ReactNode
+    children : React.ReactNode;
+    displayLimit?: number;
 }
 
+/**
+ * Props for the Menu component.
+ * @params {React.ReactNode} `children` - The content to be rendered inside the menu. Accepts `MenuItem` as a childrens.
+ * @params {number} `displayLimit` - Optional. Specifies the maximum number of items to display before enabling scroll.
+ *                                    If not provided, the menu will expand to fit all content without scrolling.
+*/
+
 export default function Menu(props: MenuProps) {
+    const [allowedHeight, setAllowedHeight] = useState<string>('fit-content');
+    const [shouldScroll, setShouldScroll] = useState<boolean>(false);
+
+    useEffect(() => {
+        if(props.displayLimit){
+            const calculatedHeight = props.displayLimit * 48;
+            setAllowedHeight(`${calculatedHeight}px`)
+            setShouldScroll(true);
+        }
+    },[props.displayLimit]);
+
     return(
         <div
             style={{
@@ -12,13 +31,13 @@ export default function Menu(props: MenuProps) {
                 // minWidth: '112px',
                 // maxWidth: '280px',
                 backgroundColor: 'rgb(var(--md-sys-color-surface-container))',
-                height: 'fit-content',
+                height: allowedHeight,
                 borderRadius: '4px',
                 display: 'flex',
                 justifyContent: 'start',
                 alignItems: 'center',
                 flexDirection: 'column',
-                // overflow: 'hidden'
+                ...(shouldScroll && { overflowY: 'scroll' })
             }}
             className="md-elevation-2"
         >

--- a/src/components/Menus/MenuItem/MenuItem.tsx
+++ b/src/components/Menus/MenuItem/MenuItem.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useEffect, useRef } from "react";
+
+type MenuItemProps = {
+    leadingIcon?: string;
+    trailingIcon?: string;
+    trailingText?: string;
+    label: string;
+    disable?: boolean;
+    children?: React.ReactNode
+};
+
+export default function MenuItem(props: MenuItemProps) {
+    const [isHovered, setIsHovered] = useState<boolean>(false);
+    const [isFocused, setIsFocused] = useState<boolean>(false);
+    const [isPressed, setIsPressed] = useState(false);
+    const menuItemRef = useRef<HTMLDivElement>(null);
+
+    // Defines where to position the child Menus of Menu-Item.
+    const [childPosition, setChildPosition] = useState<'Right' | 'Left'>('Right');
+    const [subChildren, setSubChildren] = useState<React.ReactNode>(null);
+    const [showChild, setShowChild] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (menuItemRef.current) {
+            const rect = menuItemRef.current.getBoundingClientRect();
+            const menuLeftPosition = rect.left;
+            const menuRightPosition = rect.right;
+            setChildPosition(`${menuLeftPosition > menuRightPosition ? 'Left' : 'Right'}`);
+        };
+
+        // Restricting to only display whose Children.type = `Menu`
+        const childrenArray = React.Children.toArray(props.children);
+        const subChild = childrenArray.forEach((child) => {
+            if(React.isValidElement(child)){
+                setSubChildren(child);
+            }
+        })
+    }, []);
+    return (
+        <div
+            ref={menuItemRef}
+            onMouseEnter={() => {
+                setIsHovered(true);
+                setShowChild(true);
+            }}
+            onMouseLeave={() => {
+                setIsHovered(false);
+                setShowChild(false);
+            }}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            onMouseDown={() => setIsPressed(true)}
+            onMouseUp={() => setIsPressed(false)}
+            style={{
+                width: '100%',
+                padding: '8px 12px',
+                height: '48px',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                backgroundColor: isFocused
+                    ? 'rgb(var(--md-sys-color-secondary))'
+                    : isHovered
+                        ? 'rgba(var(--md-sys-color-on-surface), 8%)'
+                        : isFocused || isPressed
+                            ? 'rgba(var(--md-sys-color-on-surface), 1%)'
+                            : 'rgb(var(--md-sys-color-surface-container))',
+                cursor: props.disable ? 'not-allowed' : 'pointer',
+                pointerEvents: props.disable ? 'none' : 'auto',
+                position: 'relative'
+            }}
+        >
+            {/* Start Side */}
+            <div
+                style={{
+                    gap: '12px',
+                    display: 'flex',
+                    justifyContent: 'start',
+                    alignItems: 'center',
+                }}
+            >
+
+                {/* leading Icon */}
+                {
+                    props.leadingIcon &&
+                    <span
+                        className="material-symbols-rounded"
+                        style={{
+                            fontSize: '24px',
+                            color: props.disable
+                                ? 'rgb(var(--md-sys-color-on-surface))'
+                                : isHovered || isFocused || isPressed
+                                    ? 'rgb(var(--md-sys-color-on-surface-variant)'
+                                    : 'rgb(var(--md-sys-color-on-surface-variant))',
+                            opacity: props.disable ? '0.38' : '',
+                        }}
+                    >
+                        {props.leadingIcon || ''}
+                    </span>
+                }
+
+                {/* label */}
+                <p
+                    style={{
+                        font: 'var(--md-sys-typescale-label-large-font)',
+                        fontWeight: 'var(--md-sys-typescale-label-large-weight)',
+                        fontSize: 'var(--md-sys-typescale-label-large-size)',
+                        lineHeight: 'var(--md-sys-typescale-label-large-line-height)',
+                        letterSpacing: 'var(--md-sys-typescale-label-large-tracking)',
+                        color: props.disable || isHovered || isFocused || isPressed ? 'rgb(var(--md-sys-color-on-surface))' : 'rgb(var(--md-sys-color-on-surface))',
+                        opacity: props.disable ? '0.38' : '',
+                    }}
+                >
+                    {props.label}
+                </p>
+
+            </div>
+
+            {/* End Side */}
+            <div
+                style={{
+                    height: '100%',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}
+            >
+                {/* Trailing Icon */}
+                {
+                    props.trailingIcon &&
+                    <span
+                        className="material-symbols-rounded"
+                        style={{
+                            fontSize: '24px',
+                            color: props.disable
+                                ? 'rgb(var(--md-sys-color-on-surface))'
+                                : isHovered || isFocused || isPressed
+                                    ? 'rgb(var(--md-sys-color-on-surface-variant)'
+                                    : 'rgb(var(--md-sys-color-on-surface-variant))',
+                            opacity: props.disable ? '0.38' : '',
+                        }}
+                    >
+                        {subChildren ? 'arrow_drop_down' :  props.trailingIcon || ''}
+                    </span>
+                }
+
+                {/* Trailing Text */}
+                {/* {
+                props.trailingText && 
+                    <span
+                        style={{
+                            font: 'var(--md-sys-typescale-label-large-font)',
+                            fontWeight: 'var(--md-sys-typescale-label-large-weight)',
+                            fontSize: 'var(--md-sys-typescale-label-large-size)',
+                            lineHeight: 'var(--md-sys-typescale-label-large-line-height)',
+                            letterSpacing: 'var(--md-sys-typescale-label-large-tracking)',                            
+                            float: 'right',
+                            backgroundColor: 'rgb(var(--md-sys-color-on-surface-variant))',
+                        }}
+                    >
+                        {props.trailingText || ''}
+                    </span>
+                } */}
+            </div>
+
+            {/*  Sub-Children */}
+            {
+                showChild &&
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        right: childPosition === 'Right' ? '100%' : '',
+                        left: childPosition === 'Left' ? '100%' : '',
+                    }}
+                >
+                    {
+                        subChildren && subChildren
+                    }
+                </div> 
+            }
+
+        </div>
+    );
+};
+

--- a/src/components/Menus/MenuItem/MenuItem.tsx
+++ b/src/components/Menus/MenuItem/MenuItem.tsx
@@ -1,15 +1,16 @@
 import React, { useState, useEffect, useRef } from "react";
 
-type MenuItemProps = {
+type MenuItemProps<T = void> = {
     leadingIcon?: string;
     trailingIcon?: string;
     trailingText?: string;
     label: string;
     disable?: boolean;
-    children?: React.ReactNode
+    children?: React.ReactNode;
+    onClickCallback?: (params: T) => void;
 };
 
-export default function MenuItem(props: MenuItemProps) {
+const MenuItem = <T,>(props: MenuItemProps<T>) => {
     const [isHovered, setIsHovered] = useState<boolean>(false);
     const [isFocused, setIsFocused] = useState<boolean>(false);
     const [isPressed, setIsPressed] = useState(false);
@@ -31,11 +32,19 @@ export default function MenuItem(props: MenuItemProps) {
         // Restricting to only display whose Children.type = `Menu`
         const childrenArray = React.Children.toArray(props.children);
         const subChild = childrenArray.forEach((child) => {
-            if(React.isValidElement(child)){
+            if (React.isValidElement(child)) {
                 setSubChildren(child);
             }
         })
     }, []);
+
+    const handleClick = () => {
+        const params = {} as T;
+        if (props.onClickCallback) {
+            props.onClickCallback(params);
+        }
+    };
+
     return (
         <div
             ref={menuItemRef}
@@ -51,6 +60,7 @@ export default function MenuItem(props: MenuItemProps) {
             onBlur={() => setIsFocused(false)}
             onMouseDown={() => setIsPressed(true)}
             onMouseUp={() => setIsPressed(false)}
+            onClick={handleClick}
             style={{
                 width: '100%',
                 padding: '8px 12px',
@@ -140,47 +150,47 @@ export default function MenuItem(props: MenuItemProps) {
                             opacity: props.disable ? '0.38' : '',
                         }}
                     >
-                        {subChildren ? 'arrow_drop_down' :  props.trailingIcon || ''}
+                        {subChildren ? 'arrow_drop_down' : props.trailingIcon || ''}
                     </span>
                 }
 
                 {/* Trailing Text */}
-                {/* {
-                props.trailingText && 
+                {
+                    props.trailingText &&
                     <span
                         style={{
                             font: 'var(--md-sys-typescale-label-large-font)',
                             fontWeight: 'var(--md-sys-typescale-label-large-weight)',
                             fontSize: 'var(--md-sys-typescale-label-large-size)',
                             lineHeight: 'var(--md-sys-typescale-label-large-line-height)',
-                            letterSpacing: 'var(--md-sys-typescale-label-large-tracking)',                            
-                            float: 'right',
-                            backgroundColor: 'rgb(var(--md-sys-color-on-surface-variant))',
+                            letterSpacing: 'var(--md-sys-typescale-label-large-tracking)',
+                            color: 'rgb(var(--md-sys-color-on-surface-variant))',
                         }}
                     >
                         {props.trailingText || ''}
                     </span>
-                } */}
+                }
             </div>
 
             {/*  Sub-Children */}
             {
                 showChild &&
-                <div
-                    style={{
-                        position: 'absolute',
-                        top: 0,
-                        right: childPosition === 'Right' ? '100%' : '',
-                        left: childPosition === 'Left' ? '100%' : '',
-                    }}
-                >
-                    {
-                        subChildren && subChildren
-                    }
-                </div> 
-            }
+            <div
+                style={{
+                    position: 'absolute',
+                    top: 0,
+                    right: childPosition === 'Right' ? '100%' : '',
+                    left: childPosition === 'Left' ? '100%' : '',
+                }}
+            >
+                {
+                    subChildren && subChildren
+                }
+            </div>
+        }
 
         </div>
     );
 };
 
+export default MenuItem;

--- a/src/components/Menus/MenuItem/MenuItem.tsx
+++ b/src/components/Menus/MenuItem/MenuItem.tsx
@@ -10,6 +10,17 @@ type MenuItemProps<T = void> = {
     onClickCallback?: (params: T) => void;
 };
 
+/**
+* Props for MenuItem Component
+* @param (string) [optional] `leadingIcon` - Icon displayed at start of item
+* @param (string) [optional] `trailingIcon` - Icon displayed at end of item  
+* @param (string) [optional] `trailingText` - Text displayed at end of item
+* @param (string) [required] `label` - Primary text content of menu item
+* @param (boolean) [optional] `disable` - Whether item is disabled
+* @param (React.ReactNode) [optional] `children` - Inner content to render
+* @param (function) [optional] `onClickCallback` - Callback fired on item click, accepts generic param
+*/
+
 const MenuItem = <T,>(props: MenuItemProps<T>) => {
     const [isHovered, setIsHovered] = useState<boolean>(false);
     const [isFocused, setIsFocused] = useState<boolean>(false);
@@ -175,19 +186,19 @@ const MenuItem = <T,>(props: MenuItemProps<T>) => {
             {/*  Sub-Children */}
             {
                 showChild &&
-            <div
-                style={{
-                    position: 'absolute',
-                    top: 0,
-                    right: childPosition === 'Right' ? '100%' : '',
-                    left: childPosition === 'Left' ? '100%' : '',
-                }}
-            >
-                {
-                    subChildren && subChildren
-                }
-            </div>
-        }
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        right: childPosition === 'Right' ? '100%' : '',
+                        left: childPosition === 'Left' ? '100%' : '',
+                    }}
+                >
+                    {
+                        subChildren && subChildren
+                    }
+                </div>
+            }
 
         </div>
     );

--- a/src/components/Menus/MenuItem/index.ts
+++ b/src/components/Menus/MenuItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MenuItem";

--- a/src/components/Menus/index.ts
+++ b/src/components/Menus/index.ts
@@ -1,0 +1,2 @@
+export { default as Menu } from "./Menu";
+export { default as MenuItem } from "./MenuItem";

--- a/src/components/TextFields/FilledTextField/FilledTextField.tsx
+++ b/src/components/TextFields/FilledTextField/FilledTextField.tsx
@@ -19,6 +19,25 @@ type FilledTextFieldProps = {
   error?: boolean;
 };
 
+/**
+* Props for OutlinedTextField Component
+* @param (string) [required] `value` - Current value of the input field
+* @param (function) [required] `onValueChange` - Handler function for value changes
+* @param ("textarea" | "" | "dropdown") [optional] `type` - Type of input field
+* @param (string[]) [optional] `options` - Available options for dropdown type
+* @param (number) [optional] `rows` - Number of rows for textarea
+* @param (string) [optional] `containerWidth` - Width of the input container
+* @param (string) [optional] `leadingIcon` - Icon displayed at start of input
+* @param (string) [required] `labelText` - Label text for the input field
+* @param (string) [optional] `inputType` - HTML input type attribute
+* @param (number) [optional] `maxLength` - Maximum allowed input length
+* @param (boolean) [optional] `required` - Whether field is required
+* @param (string) [optional] `supportingText` - Helper text below input
+* @param (string) [optional] `trailingIcon` - Icon displayed at end of input
+* @param (boolean) [optional] `disabled` - Whether field is disabled
+* @param (boolean) [optional] `error` - Whether field is in error state
+*/
+
 export default function FilledTextField(props: FilledTextFieldProps) {
   const [givenInputType, setGivenInputType] = useState<string>("");
   const [isFocused, setIsFocused] = useState(false);

--- a/src/components/TextFields/FilledTextField/FilledTextField.tsx
+++ b/src/components/TextFields/FilledTextField/FilledTextField.tsx
@@ -190,6 +190,11 @@ export default function FilledTextField(props: FilledTextFieldProps) {
               disabled={props.disabled}
               maxLength={props.maxLength}
               onChange={handleInputChange}
+              onKeyDown={(e) => {
+                if(props.type === 'dropdown'){
+                  e.preventDefault();
+                }
+              }}
               placeholder=""
               className={`filled-text-field-input ${props.error ? "error" : ""
                 }`}

--- a/src/components/TextFields/FilledTextField/FilledTextField.tsx
+++ b/src/components/TextFields/FilledTextField/FilledTextField.tsx
@@ -1,9 +1,11 @@
 import React, { MouseEvent, useEffect, useRef, useState } from "react";
+import { Menu, MenuItem } from "../../Menus";
 
 type FilledTextFieldProps = {
   value: string;
   onValueChange: (value: string) => void;
-  type?: "textarea" | "";
+  type?: "textarea" | "" | "dropdown";
+  options?: string[];
   rows?: number;
   containerWidth?: string;
   leadingIcon?: string;
@@ -21,6 +23,11 @@ export default function FilledTextField(props: FilledTextFieldProps) {
   const [givenInputType, setGivenInputType] = useState<string>("");
   const [isFocused, setIsFocused] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [menuPosition, setMenuPosition] = useState<'Top' | 'Bottom'>('Bottom');
+  const textFieldRef = useRef<HTMLDivElement>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
 
   const handleInputChange = (
     e:
@@ -30,8 +37,34 @@ export default function FilledTextField(props: FilledTextFieldProps) {
     props.onValueChange(e.target.value);
   };
 
+  const handleMenuItemClick = (value: string) => {
+    props.onValueChange(value);
+    setIsMenuOpen(false);
+  };
+
+  const handleFocus = () => {
+    setIsFocused(true);
+    if(props.type === 'dropdown'){
+      setIsMenuOpen(true);
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    if(props.type === 'dropdown'){
+      const isClickInsideMenu = menuRef.current?.contains(e.relatedTarget as Node);
+
+      if (!isClickInsideMenu) {
+        setTimeout(() => {
+          setIsFocused(false);
+        }, 200);
+      }
+    }
+    else{
+      setIsFocused(false);
+    }
+  };
+
   const handleTrailingIconClick = (e: MouseEvent<HTMLDivElement>) => {
-    console.log("trailing button is clicked");
     if (props.inputType === "password") {
       setGivenInputType(givenInputType === "text" ? "password" : "text");
     } else {
@@ -40,6 +73,7 @@ export default function FilledTextField(props: FilledTextFieldProps) {
   };
 
   useEffect(() => {
+
     if (props.type === "textarea" && textareaRef.current) {
       const textarea = textareaRef.current;
       textarea.style.height = "auto";
@@ -49,9 +83,19 @@ export default function FilledTextField(props: FilledTextFieldProps) {
     if (givenInputType === "") {
       setGivenInputType(props.inputType ?? "text");
     }
+
+    if (props.type === 'dropdown') {
+      if (textFieldRef.current) {
+        const rect = textFieldRef.current.getBoundingClientRect();
+        const menuTopPosition = rect.top;
+        const menuBottomPosition = rect.bottom;
+        setMenuPosition(`${menuTopPosition > menuBottomPosition ? 'Top' : 'Bottom'}`);
+      };
+    }
   }, [props.value, props.type]);
   return (
     <div
+      ref={textFieldRef}
       style={{
         width: props.containerWidth ?? "",
         display: "flex",
@@ -63,24 +107,23 @@ export default function FilledTextField(props: FilledTextFieldProps) {
         pointerEvents: props.disabled ? "none" : "auto",
         cursor: "pointer",
         transition: "all 0.3s ease",
+        position: "relative"
       }}
     >
       {/* Input Container ( ~ except supporting text ) */}
       <div
-        className={`filled-text-field-inner-container ${
-          isFocused ? "focused" : ""
-        } ${props.error ? "error" : ""}`}
+        className={`filled-text-field-inner-container ${isFocused ? "focused" : ""
+          } ${props.error ? "error" : ""}`}
         style={{
           width: "100%",
           minHeight: "56px",
           height: "auto",
-          padding: `${
-            props.leadingIcon && props.trailingIcon
+          padding: `${props.leadingIcon && props.trailingIcon
               ? "8px 12px"
               : props.leadingIcon
-              ? "8px 16px 8px 12px"
-              : "8px 16px"
-          }`,
+                ? "8px 16px 8px 12px"
+                : "8px 16px"
+            }`,
           borderTopLeftRadius: "4px",
           borderTopRightRadius: "4px",
           display: "flex",
@@ -88,15 +131,14 @@ export default function FilledTextField(props: FilledTextFieldProps) {
           alignItems: "center",
           gap: `${props.leadingIcon || props.trailingIcon ? "16px" : "0px"}`,
         }}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
       >
         {/* Leading Icon */}
         {props.leadingIcon && (
           <div
-            className={`filled-text-field-leading-icon ${
-              props.error && "error"
-            }`}
+            className={`filled-text-field-leading-icon ${props.error && "error"
+              }`}
             style={{
               width: "24px",
               height: "24px",
@@ -124,9 +166,8 @@ export default function FilledTextField(props: FilledTextFieldProps) {
               maxLength={props.maxLength}
               onChange={handleInputChange}
               placeholder=""
-              className={`filled-text-field-input ${
-                props.error ? "error" : ""
-              }`}
+              className={`filled-text-field-input ${props.error ? "error" : ""
+                }`}
               style={{
                 color: "rgb(var(--md-sys-color-on-surface))",
                 font: "var(--md-sys-typescale-body-large-font)",
@@ -150,9 +191,8 @@ export default function FilledTextField(props: FilledTextFieldProps) {
               maxLength={props.maxLength}
               onChange={handleInputChange}
               placeholder=""
-              className={`filled-text-field-input ${
-                props.error ? "error" : ""
-              }`}
+              className={`filled-text-field-input ${props.error ? "error" : ""
+                }`}
               style={{
                 color: "rgb(var(--md-sys-color-on-surface))",
                 font: "var(--md-sys-typescale-body-large-font)",
@@ -180,9 +220,8 @@ export default function FilledTextField(props: FilledTextFieldProps) {
         {props.trailingIcon && props.value.length > 0 && (
           <div
             onClick={(e) => handleTrailingIconClick(e)}
-            className={`filled-text-field-trailing-icon ${
-              props.error && "error"
-            }`}
+            className={`filled-text-field-trailing-icon ${props.error && "error"
+              }`}
             style={{
               width: "24px",
               height: "24px",
@@ -213,11 +252,10 @@ export default function FilledTextField(props: FilledTextFieldProps) {
           alignItems: "start",
           padding: "0px 16px",
           gap: "16px",
-          color: `${
-            props.error
+          color: `${props.error
               ? "rgb(var(--md-sys-color-error))"
               : "rgb(var(--md-sys-color-on-surface-variant))"
-          }`,
+            }`,
           font: "var(--md-sys-typescale-body-small-font)",
           fontWeight: "var(--md-sys-typescale-body-small-weight)",
           fontSize: "var(--md-sys-typescale-body-small-size)",
@@ -235,6 +273,31 @@ export default function FilledTextField(props: FilledTextFieldProps) {
           </p>
         )}
       </div>
+
+      {
+        props.type === 'dropdown' && props.options && isMenuOpen &&
+        <div
+          ref={menuRef}
+          style={{
+            position: 'absolute',
+            top: menuPosition === 'Top' ? 0 : '',
+            bottom: menuPosition === 'Bottom' ? 0 : '',
+            left: 0,
+          }}
+        >
+          <Menu>
+            {
+              props.options.map((item, index) => (
+                <MenuItem
+                  key={index}
+                  label={item}
+                  onClickCallback={() => handleMenuItemClick(item)}
+                />
+              ))
+            }
+          </Menu>
+        </div>
+      }
     </div>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export * from "./Scaffold";
 export * from "./Radio";
 export * from "./Badges";
 export * from "./Switch";
+export * from "./Menus";

--- a/src/globals.css
+++ b/src/globals.css
@@ -1146,3 +1146,31 @@ input[type="checkbox"].null:checked:before {
 .animate-transition-grow {
   animation: transition-grow .4s cubic-bezier(.2,0,0,1) 1
 }
+
+::-webkit-scrollbar {
+  width: 4px; /* Adjust the width as needed */
+  background-color: transparent; /* Make the track transparent */
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(187, 183, 183, 0.916); /* Subtle gray color */
+  border-radius: 12px; /* Rounded corners */
+}
+
+::-webkit-scrollbar-thumb:hover ~ ::-webkit-scrollbar {
+  background-color: black;
+  padding: 0px 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(187, 183, 183, 0.764); /* Darken on hover */
+}
+
+::-webkit-scrollbar-track {
+  background-color: transparent; /* Make the track transparent */
+}
+
+/* Hide the scrollbar arrows */
+::-webkit-scrollbar-button {
+  display: none;
+}


### PR DESCRIPTION
*Contains : `Menu` ( a parent component ) | `MenuItem` ( a child component )*

- Menus will work as a `standard menu`  ( just like on clicking on an icon or text or button, a Menu pop's up ) 
- MenuItem accepts sub-children, which gives more options under individual menus.
- The sub-menu's alignment ( left / right ) is dynamically calculated. Using `getBoundingClientRect`
- Also can be used under the `dropdown` for `InputTextFields`. By passing props `( type: 'dropdown' & options: string[] )`
- Accepts `display view limit` : number - number of items should be visible to the user's eye, and the rest can be viewed by scrolling.
- *Also `disabled keyboard events for InputField when type is dropdown`. To prevent user from typing & to restrict to only select from given options.*

# Preview 👁️👁️ 
### Standard Menu + Scrollable Menu

https://github.com/user-attachments/assets/9606a8be-f447-4c8d-89ca-e6317e37efca

### Dropdown Menu - FilledTextFiled

https://github.com/user-attachments/assets/1d0d9146-7c52-4704-b843-fb0e97d3ff49

### Dropdown Menu - OutlinedTextFiled

https://github.com/user-attachments/assets/8ea079b9-8c70-49c7-a125-7db3b34c6bd9

